### PR TITLE
Add failed records to error objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.1.0] - 2015-11-16
+### Changed
+- Add property `records` to error events which contains the records
+  that couldn't be written
+
 ## [0.0.4] - 2015-10-28
 ### Added
 - Keywords to package.json

--- a/api.md
+++ b/api.md
@@ -8,6 +8,6 @@ A simple wrapper around Elasticsearch for bulk writing items
 | --- | --- | --- | --- |
 | client | <code>Elasticsearch.Client</code> |  | Elasticsearch client |
 | options | <code>Object</code> |  | Options |
-| [options.highWaterMark] | <code>Number</code> | <code>16</code> | Number of items to buffer before writing. Also the size of the underlying stream buffer. |
+| [options.highWaterMark] | <code>number</code> | <code>16</code> | Number of items to buffer before writing. Also the size of the underlying stream buffer. |
 | [options.logger] | <code>Object</code> |  | Instance of a logger like bunyan or winston |
 

--- a/index.js
+++ b/index.js
@@ -79,6 +79,8 @@ ElasticsearchBulkIndexWritable.prototype._flush = function _flush(callback) {
 
     this.client.bulk({ body: records }, function bulkCallback(err, data) {
         if (err) {
+            err.records = records;
+
             return callback(err);
         }
 
@@ -93,7 +95,10 @@ ElasticsearchBulkIndexWritable.prototype._flush = function _flush(callback) {
                 errors.forEach(this.logger.error.bind(this.logger));
             }
 
-            return callback(new Error(errors));
+            var error = new Error(errors);
+            error.records = records;
+
+            return callback(error);
         }
 
         if (this.logger) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elasticsearch-bulk-index-stream",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "description": "A writable stream for bulk indexing records in Elasticsearch",
   "main": "index.js",
   "scripts": {

--- a/test/elasticsearch-bulk-stream.js
+++ b/test/elasticsearch-bulk-stream.js
@@ -107,10 +107,10 @@ describe('ElastisearchBulkIndexWritable', function() {
         });
 
         it('should trigger error on elasticsearch error', function(done) {
-            this.client.bulk.yields('Fail');
+            this.client.bulk.yields(new Error('Fail'));
 
             this.stream.on('error', function(error) {
-                expect(error).to.eq('Fail');
+                expect(error.message).to.eq('Fail');
 
                 done();
             });


### PR DESCRIPTION
Add property `records` to error events which contains the records that couldn't be written
