### PR TITLE
add timeout option for flushing stream before highWaterMark

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ will be buffered before doing a bulk indexing operation. The stream
 will also write all buffered items if its is closed, before emitting
 the `finish` event.
 
+## Flushing
+
+Its also possible to send in the option `flushTimeout` to indicate
+that the items currently in the buffer should be flushed after the
+given amount of milliseconds if the `highWaterMark` haven't been
+reached.
+
 ## Logging
 
 A [bunyan](https://www.npmjs.com/package/bunyan),
@@ -42,7 +49,10 @@ sent in as `options.logger` to the constructor.
 ```javascript
 var ElasticsearchBulkIndexStream = require('elasticsearch-bulk-index-stream');
 
-var stream = new ElasticsearchBulkIndexStream(elasticsearchClient, { highWaterMark: 256 });
+var stream = new ElasticsearchBulkIndexStream(elasticsearchClient, {
+  highWaterMark: 256,
+  flushTimeout: 500
+});
 
 someInputStream
   .pipe(stream)

--- a/index.js
+++ b/index.js
@@ -115,8 +115,11 @@ ElasticsearchBulkIndexWritable.prototype._flush = function _flush(callback) {
         return callback(error);
     }
 
+    var recordsCount = this.queue.length;
+    this.queue = [];
+
     if (this.logger) {
-        this.logger.debug('Writing %d records to Elasticsearch', this.queue.length);
+        this.logger.debug('Writing %d records to Elasticsearch', recordsCount);
     }
 
     this.bulkWrite(records, function(err) {
@@ -125,11 +128,10 @@ ElasticsearchBulkIndexWritable.prototype._flush = function _flush(callback) {
         }
 
         if (this.logger) {
-            this.logger.info('Wrote %d records to Elasticsearch', this.queue.length);
+            this.logger.info('Wrote %d records to Elasticsearch', recordsCount);
         }
 
-        this.writtenRecords += this.queue.length;
-        this.queue = [];
+        this.writtenRecords += recordsCount;
 
         callback();
     }.bind(this));

--- a/index.js
+++ b/index.js
@@ -152,6 +152,8 @@ ElasticsearchBulkIndexWritable.prototype._write = function _write(record, enc, c
     this.queue.push(record);
 
     if (this.queue.length >= this.highWaterMark) {
+        clearTimeout(this.flushTimeoutId);
+
         return this._flush(callback);
     } else if (this.flushTimeout) {
         clearTimeout(this.flushTimeoutId);

--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ function transformRecords(records) {
  * @param {Object} options Options
  * @param {number} [options.highWaterMark=16] Number of items to buffer before writing.
  * Also the size of the underlying stream buffer.
+ * @param {number} [options.flushTimeout=null] Number of ms to flush records after, if highWaterMark hasn't been reached
  * @param {Object} [options.logger] Instance of a logger like bunyan or winston
  */
 function ElasticsearchBulkIndexWritable(client, options) {

--- a/index.js
+++ b/index.js
@@ -148,20 +148,21 @@ ElasticsearchBulkIndexWritable.prototype._write = function _write(record, enc, c
     if (this.logger) {
         this.logger.debug('Adding to Elasticsearch queue', { record: record });
     }
-    var self = this;
+
     this.queue.push(record);
 
     if (this.queue.length >= this.highWaterMark) {
         return this._flush(callback);
-    } else if (self.flushTimeout) {
+    } else if (this.flushTimeout) {
         clearTimeout(this.timeoutId);
-        self.timeoutId = setTimeout(function() {
-            self._flush(function(err) {
+
+        this.timeoutId = setTimeout(function() {
+            this._flush(function(err) {
                 if (err) {
-                    self.emit('error', err);
+                    this.emit('error', err);
                 }
-            });
-        }, self.flushTimeout);
+            }.bind(this));
+        }.bind(this), this.flushTimeout);
     }
 
     callback();

--- a/index.js
+++ b/index.js
@@ -154,9 +154,9 @@ ElasticsearchBulkIndexWritable.prototype._write = function _write(record, enc, c
     if (this.queue.length >= this.highWaterMark) {
         return this._flush(callback);
     } else if (this.flushTimeout) {
-        clearTimeout(this.timeoutId);
+        clearTimeout(this.flushTimeoutId);
 
-        this.timeoutId = setTimeout(function() {
+        this.flushTimeoutId = setTimeout(function() {
             this._flush(function(err) {
                 if (err) {
                     this.emit('error', err);

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ function ElasticsearchBulkIndexWritable(client, options) {
     this.logger = options.logger || null;
 
     this.highWaterMark = options.highWaterMark || 16;
-    this.timeout = options.timeout || null;
+    this.flushTimeout = options.flushTimeout || null;
     this.writtenRecords = 0;
     this.queue = [];
 }
@@ -152,15 +152,15 @@ ElasticsearchBulkIndexWritable.prototype._write = function _write(record, enc, c
 
     if (this.queue.length >= this.highWaterMark) {
         return this._flush(callback);
-    } else if (self.timeout) {
-        clearTimeout(self.timeoutId);
+    } else if (self.flushTimeout) {
+        clearTimeout(this.timeoutId);
         self.timeoutId = setTimeout(function() {
             self._flush(function(err) {
                 if (err) {
                     self.emit('error', err);
                 }
             });
-        }, self.timeout);
+        }, self.flushTimeout);
     }
 
     callback();

--- a/test/elasticsearch-bulk-stream.js
+++ b/test/elasticsearch-bulk-stream.js
@@ -173,16 +173,13 @@ describe('ElastisearchBulkIndexWritable', function() {
             this.client.bulk.yields(null, successResponseFixture);
             this.clock = sinon.useFakeTimers();
 
-            function writeRecords(stream, number) {
-                for (var i = 0; i < number; i++) {
-                    stream.write(recordFixture);
-                }
+            for (var i = 0; i < 10; i++) {
+                this.stream.write(recordFixture);
             }
 
-            writeRecords(this.stream, 10);
             expect(this.client.bulk.callCount).to.eq(1);
 
-            writeRecords(this.stream, 1);
+            this.stream.write(recordFixture);
             this.clock.tick(1001);
             expect(this.client.bulk.callCount).to.eq(2);
         });

--- a/test/elasticsearch-bulk-stream.js
+++ b/test/elasticsearch-bulk-stream.js
@@ -156,7 +156,8 @@ describe('ElastisearchBulkIndexWritable', function() {
 
         it('should throw error on body missing in record', getMissingFieldTest('body'));
     });
-    describe('timeout', function() {
+
+    describe('flush timeout', function() {
         beforeEach(function() {
             this.client = {
                 bulk: this.sinon.stub()


### PR DESCRIPTION
We had a use case where a stream potentially would never end.  This resulted in a situation where it was desirable flush the queue after a configurable timeout to avoid the remaining values being stuck waiting for the stream to end or for the next operation where more records would flush them out. 
