### PR TITLE
allow parent type for bulk indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The records written to the stream has to have the following format:
   index: 'name-of-index',
   type: 'recordType',
   id: 'recordId',
+  parent: 'parentRecordType' //optional
   body: {
     name: 'Foo Bar'
   }

--- a/index.js
+++ b/index.js
@@ -19,13 +19,16 @@ function transformRecords(records) {
         assert(record.index, 'index is required');
         assert(record.type, 'type is required');
         assert(record.body, 'body is required');
-
+        var index = {
+            _index: record.index,
+            _type: record.type,
+            _id: record.id
+        };
+        if (record.parent) {
+            index._parent = record.parent;
+        }
         bulkOperations.push({
-            index: {
-                _index: record.index,
-                _type: record.type,
-                _id: record.id
-            }
+            index: index
         });
 
         bulkOperations.push(record.body);

--- a/test/elasticsearch-bulk-stream.js
+++ b/test/elasticsearch-bulk-stream.js
@@ -11,7 +11,9 @@ chai.use(sinonChai);
 var expect = chai.expect;
 
 var recordFixture = require('./fixture/record.json');
+var recordParentFixture = require('./fixture/parentrecord.json');
 var successResponseFixture = require('./fixture/success-response.json');
+var successParentResponseFixture = require('./fixture/success-parent-response.json');
 var errorResponseFixture = require('./fixture/error-response.json');
 
 describe('ElastisearchBulkIndexWritable', function() {
@@ -199,6 +201,43 @@ describe('ElastisearchBulkIndexWritable', function() {
 
                 done();
             }.bind(this));
+        });
+    });
+
+    describe('parent type', function() {
+        beforeEach(function() {
+            this.client = {
+                bulk: this.sinon.stub()
+            };
+
+            this.stream = new ElasticsearchBulkIndexWritable(this.client, {
+                highWaterMark: 1,
+                flushTimeout: 10
+            });
+
+            this.client.bulk.yields(null, successParentResponseFixture);
+            this.clock = sinon.useFakeTimers();
+        });
+
+        it('should include parent type in record if present', function() {
+            this.stream.write(recordParentFixture);
+            var expectedArgument = {
+                body: [
+                    {
+                        index: {
+                            _index: 'indexName',
+                            _type: 'recordType',
+                            _id: 'recordId',
+                            _parent: 'parentRecordType'
+                        }
+                    },
+                    {
+                        foo: 'bar'
+                    }
+                ]
+            };
+            expect(this.client.bulk).to.have.callCount(1);
+            expect(this.client.bulk).to.have.been.calledWith(expectedArgument);
         });
     });
 });

--- a/test/fixture/parentrecord.json
+++ b/test/fixture/parentrecord.json
@@ -1,0 +1,9 @@
+{
+    "index": "indexName",
+    "id": "recordId",
+    "type": "recordType",
+    "parent": "parentRecordType",
+    "body": {
+        "foo": "bar"
+    }
+}

--- a/test/fixture/success-parent-response.json
+++ b/test/fixture/success-parent-response.json
@@ -1,0 +1,16 @@
+{
+    "took": 30,
+    "errors": false,
+    "items": [
+        {
+            "index": {
+                "_index": "indexName",
+                "_id": "recordId",
+                "_type": "recordType",
+                "_parent": "parentRecordType",
+                "_version": 5,
+                "status": 200
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Allow Parent Child Relationship to be added to the record indices. 

Solves issue #10 
